### PR TITLE
[ADD] vendor_bills: Submodule added as dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 	path = server-tools
 	url = git@github.com:Vauxoo/server-tools.git
 	branch = 12.0
+[submodule "vendor-bills"]
+	path = vendor-bills
+	url = git@git.vauxoo.com:vauxoo/vendor-bills.git
+	branch = 12.0


### PR DESCRIPTION
I'm adding `vendor-bills` repo as a submodule here because we depend on `l10n_mx_customer_bills`.

When we use t2d and our traditional containers, this repository is automatically fetched by the script `clone_oca_dependencies` because it is a dependency of the `mexico` repository [here](https://git.vauxoo.com/vauxoo/mexico/blob/5cf06832dc84d1713e24d9897e86b56fe8e4816e/oca_dependencies.txt#L3). But it is not fetched automatically by Odoo.sh. So I need to put this dependency explicitly here as a submodule.

This is the error in Odoo.sh

![seleccion_232](https://user-images.githubusercontent.com/442938/49523510-562b9800-f880-11e8-814b-e9192d6f9cf9.png)

These are the modules automatically fetched by the t2d containers

![seleccion_231](https://user-images.githubusercontent.com/442938/49523871-026d7e80-f881-11e8-9801-34475d345d4a.png)

As you can see in the image, there are another projects not explicitly cloned here (like account-closing, product-attribute, etc) but I want to test if everything works well with just this only dependency.

/cc @rsilvam21 @moylop260 